### PR TITLE
added --remote-debugging-port to chrome options to allow tests to run…

### DIFF
--- a/tests/test_int.py
+++ b/tests/test_int.py
@@ -25,6 +25,7 @@ class TestBase(LiveServerTestCase):
 
         chrome_options = webdriver.chrome.options.Options()
         chrome_options.add_argument('--headless')
+        chrome_options.add_argument('--remote-debugging-port=9222')
 
         self.driver = webdriver.Chrome(options=chrome_options)
 


### PR DESCRIPTION
… on ubuntu 20.04